### PR TITLE
language translations to spanish (starting)

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/lib/Components/saveNote.dart
+++ b/lib/Components/saveNote.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'textnoteservice.dart';
 import 'package:untitled3/Services/textnoteservice.dart';
-import 'package:untitled3/Screens/Bottom_bar.dart';
 import 'package:untitled3/Screens/Setting.dart';
 
 final saveNoteScaffoldKey = GlobalKey<ScaffoldState>();

--- a/lib/Screens/HomeScreen.dart
+++ b/lib/Screens/HomeScreen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:untitled3/Component/Speech.dart';
 import 'Setting.dart';
 import 'package:untitled3/Model/recordnote.dart';
 

--- a/lib/Screens/Main.dart
+++ b/lib/Screens/Main.dart
@@ -59,12 +59,12 @@ class _MainNavigatorState extends  State<MainNavigator> {
 
   Widget _pickScreen(String name, index){
 
-    if(name == SCREEN_NAMES.SETTING){
+    if(name == AppLocalizations.of(context)!.settingScreenName){
       return Setting();
     }
     /**
      * TODO: Uncomment for calendar
-     * if(name == SCREEN_NAMES.CALENDAR){
+     * if(name == AppLocalizations.of(context)!.calendarScreenName){
       return Calendar();
     }*/
 
@@ -80,7 +80,7 @@ class _MainNavigatorState extends  State<MainNavigator> {
           leading: IconButton(
 
               onPressed: () {
-                _setScreenName(SCREEN_NAMES.SETTING);
+                _setScreenName(AppLocalizations.of(context)!.settingScreenName);
               },
               icon: Icon(
                 Icons.settings,
@@ -128,21 +128,21 @@ class _MainNavigatorState extends  State<MainNavigator> {
               Icons.home,
               size: 40,
             ),
-            title: Text('Menu'),
+            title: Text(AppLocalizations.of(context)!.menuScreenName),
           ),
           BottomNavigationBarItem(
             icon: Icon(
               Icons.event_note_sharp,
               size: 40,
             ),
-            title: Text('Notes'),
+            title: Text(AppLocalizations.of(context)!.notesScreenName),
           ),
           BottomNavigationBarItem(
             icon: Icon(
               Icons.notifications,
               size: 40,
             ),
-            title: Text('Notification'),
+            title: Text(AppLocalizations.of(context)!.notificationsScreenName),
           ),
           BottomNavigationBarItem(
             icon: Image.asset(

--- a/lib/Screens/Main.dart
+++ b/lib/Screens/Main.dart
@@ -7,6 +7,7 @@ import 'HomeScreen.dart';
 import 'NotificationScreen.dart';
 import 'Menu.dart';
 import '../Utility/Constant.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// This is the stateful widget that the main application instantiates.
 class MainNavigator extends StatefulWidget {
@@ -47,11 +48,10 @@ class _MainNavigatorState extends  State<MainNavigator> {
     //TODO: make sure index is less than length of array
 
     List <String> screenNames = [
-      SCREEN_NAMES.MENU,
-      SCREEN_NAMES.NOTE,
-      SCREEN_NAMES.NOTIFICATION,
-      SCREEN_NAMES.HOME,
-
+      AppLocalizations.of(context)!.menuScreenName,
+      AppLocalizations.of(context)!.notesScreenName,
+      AppLocalizations.of(context)!.notificationsScreenName,
+      AppLocalizations.of(context)!.homeScreenName,
     ];
 
     _setScreenName(screenNames[index]);

--- a/lib/Utility/Constant.dart
+++ b/lib/Utility/Constant.dart
@@ -1,4 +1,8 @@
- class SCREEN_NAMES {
+import 'dart:ui';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SCREEN_NAMES {
    static final String MENU = "MENU";
    static final String NOTE = "NOTE";
    static final String HOME = "HOME";
@@ -7,3 +11,12 @@
    static final String CALENDAR = "CALENDAR";
 
  }
+
+ const SUPPORTED_LOCALES = [Locale('en', 'US'), Locale('es', 'US')];
+
+const LOCALIZATION_DELEGATES = [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+       GlobalWidgetsLocalizations.delegate,
+       GlobalCupertinoLocalizations.delegate,
+];

--- a/lib/Utility/Constant.dart
+++ b/lib/Utility/Constant.dart
@@ -2,16 +2,6 @@ import 'dart:ui';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-class SCREEN_NAMES {
-   static final String MENU = "MENU";
-   static final String NOTE = "NOTE";
-   static final String HOME = "HOME";
-   static final String NOTIFICATION = "NOTIFICATION";
-   static final String SETTING = "SETTING";
-   static final String CALENDAR = "CALENDAR";
-
- }
-
  const SUPPORTED_LOCALES = [Locale('en', 'US'), Locale('es', 'US')];
 
 const LOCALIZATION_DELEGATES = [

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,18 @@
+{
+  "homeScreenName": "Home",
+  "menuScreenName": "Menu",
+  "notesScreenName": "Notes",
+  "notificationsScreenName": "Notifications",
+  "@MenuScreenName": {
+    "description": "Screen Name for Menu"
+  },
+  "@HomeScreenName": {
+    "description": "Screen Name for Home"
+  },
+  "@NotesScreenName": {
+    "description": "Screen Name for Notes"
+  },
+  "@NotificationsScreenName": {
+    "description": "Screen Name for Notifications"
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,16 +3,7 @@
   "menuScreenName": "Menu",
   "notesScreenName": "Notes",
   "notificationsScreenName": "Notifications",
-  "@MenuScreenName": {
-    "description": "Screen Name for Menu"
-  },
-  "@HomeScreenName": {
-    "description": "Screen Name for Home"
-  },
-  "@NotesScreenName": {
-    "description": "Screen Name for Notes"
-  },
-  "@NotificationsScreenName": {
-    "description": "Screen Name for Notifications"
-  }
+  "settingScreenName": "Setting",
+  "calendarScreenName": "Calendar",
+  "micButton": "Mic"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2,5 +2,8 @@
     "homeScreenName": "Casa",
     "menuScreenName": "Menu",
     "notesScreenName": "Notas",
-    "notificationsScreenName": "Notificaciones"
+    "notificationsScreenName": "Notificaciones",
+    "settingScreenName": "Setting",
+    "calendarScreenName": "Calendar",
+    "micButton": "Mic"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,6 @@
+{
+    "homeScreenName": "Casa",
+    "menuScreenName": "Menu",
+    "notesScreenName": "Notas",
+    "notificationsScreenName": "Notificaciones"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,33 +1,33 @@
+// Official
 import 'package:flutter/material.dart';
-import 'package:untitled3/Screens/Home.dart';
+
+// Internal
 import 'package:untitled3/Screens/Setting.dart';
 import 'package:untitled3/Components/saveNote.dart';
 import 'package:untitled3/Screens/Note.dart';
 import 'package:untitled3/Components/notedetails.dart';
 
 import 'Screens/Main.dart';
+import 'Utility/Constant.dart';
 
-
-void main(){
+void main() {
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget{
-
+class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: MainNavigator(),
-
+      localizationsDelegates: LOCALIZATION_DELEGATES,
+      supportedLocales: SUPPORTED_LOCALES,
       routes: {
         '/save-note': (context) => SaveNote(),
-
         '/view-notes': (context) => ViewNotes(),
-        '/note-details' :(context) => NoteDetails(),
-        '/Setting' :(context) => Setting(),
+        '/note-details': (context) => NoteDetails(),
+        '/Setting': (context) => Setting(),
       },
-
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   speech_to_text: ^5.0.0
   highlight_text: ^1.1.0
   avatar_glow: ^2.0.1
@@ -66,6 +68,7 @@ flutter_icons:
 
 # The following section is specific to Flutter.
 flutter:
+  generate: true
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
To test:

On android API 29

Go to main screen
Open settings drawer
Go to system
Chose Languages and Input
Chose Languages
Add Spanish
Drag it to #1 in the list
Reopen the app (you may need to force close it and open again)

Result:

For now, the screen names are in Spanish: 

![image](https://user-images.githubusercontent.com/3461028/134264691-d16762c0-c17a-4c3a-8e8b-73d8809c6ae3.png)


