### PR TITLE
change the way to init language

### DIFF
--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -36,7 +36,7 @@
     "medium": "Médio",
     "large": "Grande",
     "cancel": "Cancelar",
-    "save": "Salve ",
+    "save": "Salve",
     "securitySettings": "Configurações de segurança",
     "permissionNote": "NOTA: Esta permissão permitirá todos os tipos de interação por voz.",
     "daysToKeepNotes": "Dias para fazer anotações",

--- a/lib/Observables/SettingObservable.dart
+++ b/lib/Observables/SettingObservable.dart
@@ -1,6 +1,7 @@
 import 'package:mobx/mobx.dart';
 import 'package:untitled3/Model/Setting.dart';
 import 'package:untitled3/Services/SettingService.dart';
+import 'package:untitled3/generated/i18n.dart';
 
 part 'SettingObservable.g.dart';
 
@@ -10,7 +11,6 @@ abstract class _AbstractSettingObserver with Store {
 
   _AbstractSettingObserver(){
     SettingService.loadSetting().then((value) => initSettings(value));
-
   }
 
   @observable
@@ -30,6 +30,7 @@ abstract class _AbstractSettingObserver with Store {
   void initSettings(settings){
     print("Initialize settings : ${settings}");
     userSettings = settings;
+    I18n.onLocaleChanged!(settings.locale ?? DEFAULT_LOCALE);
   }
 
   @action

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,6 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     final i18n = I18n.delegate;
-    onLocaleChange(settingObserver.userSettings.locale);
     BottomNavigationBarThemeData bottomNavigationBarThemeData =
         BottomNavigationBarThemeData(
             backgroundColor:


### PR DESCRIPTION
The app was not reapplying the correct language the user had saved when they reloaded the app. This fixes that issue. 

![image](https://user-images.githubusercontent.com/3461028/138518352-8e3c9c8a-6b11-40fb-a770-2f855ba4827e.png)
